### PR TITLE
Enable CI testing

### DIFF
--- a/profile_collection/startup/00-startup.py
+++ b/profile_collection/startup/00-startup.py
@@ -1,3 +1,42 @@
+###############################################################################
+# TODO: remove this block once https://github.com/bluesky/ophyd/pull/959 is
+# merged/released.
+from datetime import datetime
+from ophyd.signal import EpicsSignalBase, EpicsSignal, DEFAULT_CONNECTION_TIMEOUT
+
+def print_now():
+    return datetime.strftime(datetime.now(), '%Y-%m-%d %H:%M:%S.%f')
+
+def wait_for_connection_base(self, timeout=DEFAULT_CONNECTION_TIMEOUT):
+    '''Wait for the underlying signals to initialize or connect'''
+    if timeout is DEFAULT_CONNECTION_TIMEOUT:
+        timeout = self.connection_timeout
+    # print(f'{print_now()}: waiting for {self.name} to connect within {timeout:.4f} s...')
+    start = time.time()
+    try:
+        self._ensure_connected(self._read_pv, timeout=timeout)
+        # print(f'{print_now()}: waited for {self.name} to connect for {time.time() - start:.4f} s.')
+    except TimeoutError:
+        if self._destroyed:
+            raise DestroyedError('Signal has been destroyed')
+        raise
+
+def wait_for_connection(self, timeout=DEFAULT_CONNECTION_TIMEOUT):
+    '''Wait for the underlying signals to initialize or connect'''
+    if timeout is DEFAULT_CONNECTION_TIMEOUT:
+        timeout = self.connection_timeout
+    # print(f'{print_now()}: waiting for {self.name} to connect within {timeout:.4f} s...')
+    start = time.time()
+    self._ensure_connected(self._read_pv, self._write_pv, timeout=timeout)
+    # print(f'{print_now()}: waited for {self.name} to connect for {time.time() - start:.4f} s.')
+
+EpicsSignalBase.wait_for_connection = wait_for_connection_base
+EpicsSignal.wait_for_connection = wait_for_connection
+###############################################################################
+
+from ophyd.signal import EpicsSignalBase
+# EpicsSignalBase.set_default_timeout(timeout=10, connection_timeout=10)  # old style
+EpicsSignalBase.set_defaults(timeout=10, connection_timeout=10)  # new style
 
 import nslsii
 nslsii.configure_base(get_ipython().user_ns, 'ixs')


### PR DESCRIPTION
Enables continuous integration testing pipeline for the `profile_collection` startup files. Also adds a fix for timeout errors in CI.