### PR TITLE
Add labels to device objects

### DIFF
--- a/startup/10-machine.py
+++ b/startup/10-machine.py
@@ -3,14 +3,17 @@ from ophyd import (Device, EpicsSignal, EpicsSignalRO,
                    Component as Cpt)
 
 
+# List of available EpicsMotor labels in this script
+# [crl. fes]
+
 # SR current
 # CNT012 src  SRcur  SR:C03-BI{DCCT:1}I:Real-I
 sr_curr = EpicsSignalRO('SR:OPS-BI{DCCT:1}I:Real-I', name='sr_curr')
 
 class CRL(Device):
-    x = Cpt(EpicsMotor, '-Ax:X}Mtr')
-    y = Cpt(EpicsMotor, '-Ax:Y}Mtr')
-    th =Cpt(EpicsMotor, '-Ax:P}Mtr')
+    x = Cpt(EpicsMotor, '-Ax:X}Mtr', labels=('crl',))
+    y = Cpt(EpicsMotor, '-Ax:Y}Mtr', labels=('crl',))
+    th =Cpt(EpicsMotor, '-Ax:P}Mtr', labels=('crl',))
 
 
 class Slit2DGap(PVPositionerPC):
@@ -36,10 +39,10 @@ class Slit2D(Device):
 
 
 class Slit2DBlades(Device):
-    top = Cpt(EpicsMotor, '1-Ax:T}Mtr')
-    bottom = Cpt(EpicsMotor, '2-Ax:B}Mtr')
-    outboard = Cpt(EpicsMotor, '1-Ax:O}Mtr')
-    inboard = Cpt(EpicsMotor, '2-Ax:I}Mtr')
+    top = Cpt(EpicsMotor, '1-Ax:T}Mtr', labels=('fes',))
+    bottom = Cpt(EpicsMotor, '2-Ax:B}Mtr', labels=('fes',))
+    outboard = Cpt(EpicsMotor, '1-Ax:O}Mtr', labels=('fes',))
+    inboard = Cpt(EpicsMotor, '2-Ax:I}Mtr', labels=('fes',))
 
 
 class FESlits(Slit2DBlades, Slit2D):

--- a/startup/10-optics.py
+++ b/startup/10-optics.py
@@ -2,6 +2,10 @@ from ophyd import (Device, Component as Cpt, EpicsMotor, PVPositioner,
                    FormattedComponent as FCpt)
 
 
+# List of available EpicsMotor labels in this script
+# [dcm. hrm2, vfm, hfm, xymotor, ssa, table, pinhole, bpm1, bpm1_diag, bpm2, bpm2_diag]
+
+
 # defined here, also used in 10-optics.py
 # why do none of the 'slits' constructs feature gap, center motions?
 class Blades(Device):
@@ -12,75 +16,75 @@ class Blades(Device):
 
 
 class DCM(Device):
-    y =  Cpt(EpicsMotor, '-Ax:Y}Mtr')
-    th = Cpt(EpicsMotor, '-Ax:P}Mtr')
-    z2 = Cpt(EpicsMotor, '-Ax:Z2}Mtr')
-    p1 = Cpt(EpicsMotor, '-Ax:P1}Mtr')
-    r2 = Cpt(EpicsMotor, '-Ax:R2}Mtr')
-    pf = Cpt(EpicsMotor, '-Ax:PF}Mtr')
+    y =  Cpt(EpicsMotor, '-Ax:Y}Mtr', labels=('dcm',))
+    th = Cpt(EpicsMotor, '-Ax:P}Mtr', labels=('dcm',))
+    z2 = Cpt(EpicsMotor, '-Ax:Z2}Mtr', labels=('dcm',))
+    p1 = Cpt(EpicsMotor, '-Ax:P1}Mtr', labels=('dcm',))
+    r2 = Cpt(EpicsMotor, '-Ax:R2}Mtr', labels=('dcm',))
+    pf = Cpt(EpicsMotor, '-Ax:PF}Mtr', labels=('dcm',))
 
 
 class HRM2(Device):
-    ux =  Cpt(EpicsMotor, '-Ax:UX}Mtr')
-    uy =  Cpt(EpicsMotor, '-Ax:UY}Mtr')
-    uth = Cpt(EpicsMotor, '-Ax:UTc}Mtr')
-    uch = Cpt(EpicsMotor, '-Ax:UC}Mtr')
-    uif = Cpt(EpicsMotor, '-Ax:UTI}Mtr')
-    uof = Cpt(EpicsMotor, '-Ax:UTO}Mtr')
-    dx =  Cpt(EpicsMotor, '-Ax:DX}Mtr')
-    dy =  Cpt(EpicsMotor, '-Ax:DY}Mtr')
-    dth = Cpt(EpicsMotor, '-Ax:DTc}Mtr')
-    dch = Cpt(EpicsMotor, '-Ax:DC}Mtr')
-    dif = Cpt(EpicsMotor, '-Ax:DTI}Mtr')
-    dof = Cpt(EpicsMotor, '-Ax:DTO}Mtr')
-    d1 =  Cpt(EpicsMotor, '-Pico:m1}Mtr')
-    d2 =  Cpt(EpicsMotor, '-Pico:m2}Mtr')
-    d3 =  Cpt(EpicsMotor, '-Pico:m3}Mtr')
-    d4 =  Cpt(EpicsMotor, '-Pico:m4}Mtr')
-    d5 =  Cpt(EpicsMotor, '-Pico:m5}Mtr')
-    bs =  Cpt(EpicsMotor, '-Pico:m6}Mtr')
+    ux =  Cpt(EpicsMotor, '-Ax:UX}Mtr', labels=('hrm2',))
+    uy =  Cpt(EpicsMotor, '-Ax:UY}Mtr', labels=('hrm2',))
+    uth = Cpt(EpicsMotor, '-Ax:UTc}Mtr', labels=('hrm2',))
+    uch = Cpt(EpicsMotor, '-Ax:UC}Mtr', labels=('hrm2',))
+    uif = Cpt(EpicsMotor, '-Ax:UTI}Mtr', labels=('hrm2',))
+    uof = Cpt(EpicsMotor, '-Ax:UTO}Mtr', labels=('hrm2',))
+    dx =  Cpt(EpicsMotor, '-Ax:DX}Mtr', labels=('hrm2',))
+    dy =  Cpt(EpicsMotor, '-Ax:DY}Mtr', labels=('hrm2',))
+    dth = Cpt(EpicsMotor, '-Ax:DTc}Mtr', labels=('hrm2',))
+    dch = Cpt(EpicsMotor, '-Ax:DC}Mtr', labels=('hrm2',))
+    dif = Cpt(EpicsMotor, '-Ax:DTI}Mtr', labels=('hrm2',))
+    dof = Cpt(EpicsMotor, '-Ax:DTO}Mtr', labels=('hrm2',))
+    d1 =  Cpt(EpicsMotor, '-Pico:m1}Mtr', labels=('hrm2',))
+    d2 =  Cpt(EpicsMotor, '-Pico:m2}Mtr', labels=('hrm2',))
+    d3 =  Cpt(EpicsMotor, '-Pico:m3}Mtr', labels=('hrm2',))
+    d4 =  Cpt(EpicsMotor, '-Pico:m4}Mtr', labels=('hrm2',))
+    d5 =  Cpt(EpicsMotor, '-Pico:m5}Mtr', labels=('hrm2',))
+    bs =  Cpt(EpicsMotor, '-Pico:m6}Mtr', labels=('hrm2',))
 
 
 
 class VFM(Device):
-    ux = Cpt(EpicsMotor, '-Ax:UX}Mtr')
-    uy = Cpt(EpicsMotor, '-Ax:UY}Mtr')
-    dx = Cpt(EpicsMotor, '-Ax:DX}Mtr')
-    dy = Cpt(EpicsMotor, '-Ax:DY}Mtr')
-    ub = Cpt(EpicsMotor, '-Ax:UB}Mtr')
-    db = Cpt(EpicsMotor, '-Ax:DB}Mtr')
+    ux = Cpt(EpicsMotor, '-Ax:UX}Mtr', labels=('vfm',))
+    uy = Cpt(EpicsMotor, '-Ax:UY}Mtr', labels=('vfm',))
+    dx = Cpt(EpicsMotor, '-Ax:DX}Mtr', labels=('vfm',))
+    dy = Cpt(EpicsMotor, '-Ax:DY}Mtr', labels=('vfm',))
+    ub = Cpt(EpicsMotor, '-Ax:UB}Mtr', labels=('vfm',))
+    db = Cpt(EpicsMotor, '-Ax:DB}Mtr', labels=('vfm',))
 
 
 class HFM(Device):
-    ux = Cpt(EpicsMotor, '-Ax:UX}Mtr')
-    uy = Cpt(EpicsMotor, '-Ax:UY}Mtr')
-    dx = Cpt(EpicsMotor, '-Ax:DX}Mtr')
-    dy = Cpt(EpicsMotor, '-Ax:DY}Mtr')
-    ub = Cpt(EpicsMotor, '-Ax:UB}Mtr')
-    db = Cpt(EpicsMotor, '-Ax:DB}Mtr')
+    ux = Cpt(EpicsMotor, '-Ax:UX}Mtr', labels=('hfm',))
+    uy = Cpt(EpicsMotor, '-Ax:UY}Mtr', labels=('hfm',))
+    dx = Cpt(EpicsMotor, '-Ax:DX}Mtr', labels=('hfm',))
+    dy = Cpt(EpicsMotor, '-Ax:DY}Mtr', labels=('hfm',))
+    ub = Cpt(EpicsMotor, '-Ax:UB}Mtr', labels=('hfm',))
+    db = Cpt(EpicsMotor, '-Ax:DB}Mtr', labels=('hfm',))
 
 
 class XYMotor(Device):
-    x = Cpt(EpicsMotor, '-Ax:X}Mtr')
-    y = Cpt(EpicsMotor, '-Ax:Y}Mtr')
+    x = Cpt(EpicsMotor, '-Ax:X}Mtr', labels=('xymotor',))
+    y = Cpt(EpicsMotor, '-Ax:Y}Mtr', labels=('xymotor',))
 
 
 class SSA(Device):
-    top = Cpt(EpicsMotor, '-Ax:T}Mtr')
-    bottom = Cpt(EpicsMotor, '-Ax:B}Mtr')
+    top = Cpt(EpicsMotor, '-Ax:T}Mtr', labels=('ssa',))
+    bottom = Cpt(EpicsMotor, '-Ax:B}Mtr', labels=('ssa',))
 
 
 class Table(Device):
-    x = Cpt(EpicsMotor, '-Ax:X4}Mtr')
-    y = Cpt(EpicsMotor, '-Ax:Y4}Mtr')
-    th =Cpt(EpicsMotor, '-Ax:X4a1}Mtr')
+    x = Cpt(EpicsMotor, '-Ax:X4}Mtr', labels=('table',))
+    y = Cpt(EpicsMotor, '-Ax:Y4}Mtr', labels=('table',))
+    th =Cpt(EpicsMotor, '-Ax:X4a1}Mtr', labels=('table',))
 
 
 class Pinhole(Device):
-    ux = Cpt(EpicsMotor, '-Ax:UX}Mtr')
-    uy = Cpt(EpicsMotor, '-Ax:UY}Mtr')
-    dx = Cpt(EpicsMotor, '-Ax:DX}Mtr')
-    dy = Cpt(EpicsMotor, '-Ax:DY}Mtr')
+    ux = Cpt(EpicsMotor, '-Ax:UX}Mtr', labels=('pinhole',))
+    uy = Cpt(EpicsMotor, '-Ax:UY}Mtr', labels=('pinhole',))
+    dx = Cpt(EpicsMotor, '-Ax:DX}Mtr', labels=('pinhole',))
+    dy = Cpt(EpicsMotor, '-Ax:DY}Mtr', labels=('pinhole',))
 
 
 class MCMBase(PVPositioner):
@@ -121,10 +125,10 @@ s1 = Blades('XF:10IDA-OP{Slt:1', name='s1')
 s2 = Blades('XF:10IDC-OP{Slt:4', name='s2')
 s3 = Blades('XF:10IDD-OP{Slt:5', name='s3')
 
-bpm1 = XYMotor('XF:10IDA-OP{BPM:1', name='bpm1')
-bpm1_diag = EpicsMotor('XF:10IDA-BI{BPM:1-Ax:YFoil}Mtr', name='bpm1_diag')
-bpm2 = XYMotor('XF:10IDC-OP{BPM:2', name='bpm2')
-bpm2_diag = EpicsMotor('XF:10IDC-BI{BPM:2-Ax:Y}Mtr', name='bpm2_diag')
+bpm1 = XYMotor('XF:10IDA-OP{BPM:1', name='bpm1', labels=('bpm1',))
+bpm1_diag = EpicsMotor('XF:10IDA-BI{BPM:1-Ax:YFoil}Mtr', name='bpm1_diag', labels=('bpm1_diag',))
+bpm2 = XYMotor('XF:10IDC-OP{BPM:2', name='bpm2', labels=('bpm2',))
+bpm2_diag = EpicsMotor('XF:10IDC-BI{BPM:2-Ax:Y}Mtr', name='bpm2_diag', labels=('bpm2_diag',))
 
 ssa = SSA('XF:10IDB-OP{SSA:1', name='ssa')
 k3 = Table('XF:10IDC-OP{Tbl:1', name='k3')

--- a/startup/25-pseudomotors.py
+++ b/startup/25-pseudomotors.py
@@ -4,6 +4,8 @@ from ophyd.pseudopos import (pseudo_position_argument, real_position_argument)
 import numpy as np
 from scipy import interpolate
 
+# List of available EpicsMotor labels in this script
+# [blenergy, dcmenergy, hrmenergy, analyzercxtal]
 
 _ivu_gap = [6184.0, 6368.0, 6550.0, 6730.0, 6909.0, 7086.0, 7262.0,
             7438.0, 7613.0, 7788.0, 7962.0, 8138.0, 8311.0, 8486.0,
@@ -27,8 +29,8 @@ class BLEnergy(PseudoPositioner):
     # limits and constants from Spec file, "site.mac"
     energy = Cpt(PseudoSingle, limits=(7.835, 17.7))
 
-    theta = Cpt(EpicsMotor, 'XF:10IDA-OP{Mono:DCM-Ax:P}Mtr')
-    z2 = Cpt(EpicsMotor, 'XF:10IDA-OP{Mono:DCM-Ax:Z2}Mtr')
+    theta = Cpt(EpicsMotor, 'XF:10IDA-OP{Mono:DCM-Ax:P}Mtr', labels=('blenergy',))
+    z2 = Cpt(EpicsMotor, 'XF:10IDA-OP{Mono:DCM-Ax:Z2}Mtr', labels=('blenergy',))
     ugap = Cpt(Undulator, 'SR:C10-ID:G1{IVU22:1')
 
     def forward(self, pseudo_pos):
@@ -51,8 +53,8 @@ class DCMEnergy(PseudoPositioner):
     # limits and constants from Spec file, "site.mac"
     energy = Cpt(PseudoSingle, limits=(7.835, 17.7))
 
-    theta = Cpt(EpicsMotor, 'XF:10IDA-OP{Mono:DCM-Ax:P}Mtr')
-    z2 = Cpt(EpicsMotor, 'XF:10IDA-OP{Mono:DCM-Ax:Z2}Mtr')
+    theta = Cpt(EpicsMotor, 'XF:10IDA-OP{Mono:DCM-Ax:P}Mtr', labels=('dcmenergy',))
+    z2 = Cpt(EpicsMotor, 'XF:10IDA-OP{Mono:DCM-Ax:Z2}Mtr', labels=('dcmenergy',))
 
     def forward(self, pseudo_pos):
         _th = np.rad2deg(np.arcsin(_hc/(2.*_si_111*pseudo_pos)))
@@ -77,8 +79,8 @@ _EB = 9.1317
 class HRMEnergy(PseudoPositioner):
     energy = Cpt(PseudoSingle)
 
-    uof = Cpt(EpicsMotor, 'XF:10IDB-OP{Mono:HRM2-Ax:UTO}Mtr')
-    dof = Cpt(EpicsMotor, 'XF:10IDB-OP{Mono:HRM2-Ax:DTO}Mtr')
+    uof = Cpt(EpicsMotor, 'XF:10IDB-OP{Mono:HRM2-Ax:UTO}Mtr', labels=('hrmenergy',))
+    dof = Cpt(EpicsMotor, 'XF:10IDB-OP{Mono:HRM2-Ax:DTO}Mtr', labels=('hrmenergy',))
 
     def forward(self, pseudo_pos):
         _pos = -1.0*pseudo_pos.energy*np.tan(np.deg2rad(_TB))/_EB
@@ -121,8 +123,8 @@ class AnalyzerCXtal(PseudoPositioner):
     the = Cpt(PseudoSingle, egu='deg')
     y = Cpt(PseudoSingle, egu='mm')
 
-    uy = Cpt(EpicsMotor, 'XF:10IDD-OP{Analy:1-Ax:UY}Mtr')
-    dy = Cpt(EpicsMotor, 'XF:10IDD-OP{Analy:1-Ax:DY}Mtr')
+    uy = Cpt(EpicsMotor, 'XF:10IDD-OP{Analy:1-Ax:UY}Mtr', labels=('analyzercxtal',))
+    dy = Cpt(EpicsMotor, 'XF:10IDD-OP{Analy:1-Ax:DY}Mtr', labels=('analyzercxtal',))
 
     @pseudo_position_argument
     def forward(self, pseudopos):

--- a/startup/90-endstation.py
+++ b/startup/90-endstation.py
@@ -1,62 +1,64 @@
 from ophyd import (Component as Cpt, Device, EpicsMotor)
 
+# List of available EpicsMotor labels in this script
+# [analyzer, spectrometer, analyzerdxtals, analyzerslits, mcmslits, samplestage, whl, anapd, anpd]
 
 class Analyzer(Device):
-    uy = Cpt(EpicsMotor, '-OP{Analy:1-Ax:UY}Mtr')
-    dy = Cpt(EpicsMotor, '-OP{Analy:1-Ax:DY}Mtr')
-    ay = Cpt(EpicsMotor, '-OP{Analy:1-Ax:A}Mtr')
-    by = Cpt(EpicsMotor, '-OP{Analy:1-Ax:B}Mtr')
+    uy = Cpt(EpicsMotor, '-OP{Analy:1-Ax:UY}Mtr', labels=('analyzer',))
+    dy = Cpt(EpicsMotor, '-OP{Analy:1-Ax:DY}Mtr', labels=('analyzer',))
+    ay = Cpt(EpicsMotor, '-OP{Analy:1-Ax:A}Mtr', labels=('analyzer',))
+    by = Cpt(EpicsMotor, '-OP{Analy:1-Ax:B}Mtr', labels=('analyzer',))
 
-    cfth = Cpt(EpicsMotor, '-ES{Ez4:1-Ax:1}Mtr')
-    cchi = Cpt(EpicsMotor, '-ES{Ez4:1-Ax:2}Mtr')
-    wfth = Cpt(EpicsMotor, '-ES{Ez4:1-Ax:3}Mtr')
-    wchi = Cpt(EpicsMotor, '-ES{Ez4:1-Ax:4}Mtr')
+    cfth = Cpt(EpicsMotor, '-ES{Ez4:1-Ax:1}Mtr', labels=('analyzer',))
+    cchi = Cpt(EpicsMotor, '-ES{Ez4:1-Ax:2}Mtr', labels=('analyzer',))
+    wfth = Cpt(EpicsMotor, '-ES{Ez4:1-Ax:3}Mtr', labels=('analyzer',))
+    wchi = Cpt(EpicsMotor, '-ES{Ez4:1-Ax:4}Mtr', labels=('analyzer',))
 
 
 class Spectrometer(Device):
-    tth = Cpt(EpicsMotor, '-OP{Spec:1-Ax:2Th}Mtr')
-    th = Cpt(EpicsMotor, '-OP{Spec:1-Ax:Th}Mtr')
-    chi = Cpt(EpicsMotor, '-OP{Spec:1-Ax:ChiA}Mtr')
-    phi = Cpt(EpicsMotor, '-OP{Spec:1-Ax:PhiA}Mtr')
+    tth = Cpt(EpicsMotor, '-OP{Spec:1-Ax:2Th}Mtr', labels=('spectrometer',))
+    th = Cpt(EpicsMotor, '-OP{Spec:1-Ax:Th}Mtr', labels=('spectrometer',))
+    chi = Cpt(EpicsMotor, '-OP{Spec:1-Ax:ChiA}Mtr', labels=('spectrometer',))
+    phi = Cpt(EpicsMotor, '-OP{Spec:1-Ax:PhiA}Mtr', labels=('spectrometer',))
 
 
 class AnalyzerDXtals(Device):
-    d1the = Cpt(EpicsMotor, '2-Ax:1}Mtr')
-    d1phi = Cpt(EpicsMotor, '2-Ax:2}Mtr')
-    d2the = Cpt(EpicsMotor, '2-Ax:3}Mtr')
-    d2phi = Cpt(EpicsMotor, '2-Ax:4}Mtr')
-    d3the = Cpt(EpicsMotor, '3-Ax:1}Mtr')
-    d3phi = Cpt(EpicsMotor, '3-Ax:2}Mtr')
-    d4the = Cpt(EpicsMotor, '3-Ax:3}Mtr')
-    d4phi = Cpt(EpicsMotor, '3-Ax:4}Mtr')
-    d5the = Cpt(EpicsMotor, '4-Ax:1}Mtr')
-    d5phi = Cpt(EpicsMotor, '4-Ax:2}Mtr')
-    d6the = Cpt(EpicsMotor, '4-Ax:3}Mtr')
-    d6phi = Cpt(EpicsMotor, '4-Ax:4}Mtr')
-    anpd = Cpt(EpicsMotor,  '5-Ax:1}Mtr')
+    d1the = Cpt(EpicsMotor, '2-Ax:1}Mtr', labels=('analyzerdxtals',))
+    d1phi = Cpt(EpicsMotor, '2-Ax:2}Mtr', labels=('analyzerdxtals',))
+    d2the = Cpt(EpicsMotor, '2-Ax:3}Mtr', labels=('analyzerdxtals',))
+    d2phi = Cpt(EpicsMotor, '2-Ax:4}Mtr', labels=('analyzerdxtals',))
+    d3the = Cpt(EpicsMotor, '3-Ax:1}Mtr', labels=('analyzerdxtals',))
+    d3phi = Cpt(EpicsMotor, '3-Ax:2}Mtr', labels=('analyzerdxtals',))
+    d4the = Cpt(EpicsMotor, '3-Ax:3}Mtr', labels=('analyzerdxtals',))
+    d4phi = Cpt(EpicsMotor, '3-Ax:4}Mtr', labels=('analyzerdxtals',))
+    d5the = Cpt(EpicsMotor, '4-Ax:1}Mtr', labels=('analyzerdxtals',))
+    d5phi = Cpt(EpicsMotor, '4-Ax:2}Mtr', labels=('analyzerdxtals',))
+    d6the = Cpt(EpicsMotor, '4-Ax:3}Mtr', labels=('analyzerdxtals',))
+    d6phi = Cpt(EpicsMotor, '4-Ax:4}Mtr', labels=('analyzerdxtals',))
+    anpd = Cpt(EpicsMotor,  '5-Ax:1}Mtr', labels=('analyzerdxtals',))
 
 
 class AnalyzerSlits(Device):
-    top = Cpt(EpicsMotor,  '5-Ax:2}Mtr')
-    bottom = Cpt(EpicsMotor,  '5-Ax:3}Mtr')
-    outboard = Cpt(EpicsMotor,  '7-Ax:3}Mtr')
-    inboard = Cpt(EpicsMotor,  '7-Ax:4}Mtr')
+    top = Cpt(EpicsMotor,  '5-Ax:2}Mtr', labels=('analyzerslits',))
+    bottom = Cpt(EpicsMotor,  '5-Ax:3}Mtr', labels=('analyzerslits',))
+    outboard = Cpt(EpicsMotor,  '7-Ax:3}Mtr', labels=('analyzerslits',))
+    inboard = Cpt(EpicsMotor,  '7-Ax:4}Mtr', labels=('analyzerslits',))
 
 
 class MCMSlits(Device):
-    top = Cpt(EpicsMotor, '6-Ax:3}Mtr')
-    bottom = Cpt(EpicsMotor, '6-Ax:4}Mtr')
-    inboard = Cpt(EpicsMotor,  '7-Ax:1}Mtr')
-    outboard = Cpt(EpicsMotor,  '7-Ax:2}Mtr')
+    top = Cpt(EpicsMotor, '6-Ax:3}Mtr', labels=('mcmslits',))
+    bottom = Cpt(EpicsMotor, '6-Ax:4}Mtr', labels=('mcmslits',))
+    inboard = Cpt(EpicsMotor,  '7-Ax:1}Mtr', labels=('mcmslits',))
+    outboard = Cpt(EpicsMotor,  '7-Ax:2}Mtr', labels=('mcmslits',))
 
 
 class SampleStage(Device):
-    ty = Cpt(EpicsMotor, '{Spec:1-Ax:Y}Mtr')
-    tx = Cpt(EpicsMotor, '{Spec:1-Ax:X}Mtr')
-    tz = Cpt(EpicsMotor, '{Spec:1-Ax:Z}Mtr')
-    sy = Cpt(EpicsMotor, '{Env:1-Ax:Y}Mtr')
-    sx = Cpt(EpicsMotor, '{Env:1-Ax:X}Mtr')
-    sz = Cpt(EpicsMotor, '{Env:1-Ax:Z}Mtr')
+    ty = Cpt(EpicsMotor, '{Spec:1-Ax:Y}Mtr', labels=('samplestage',))
+    tx = Cpt(EpicsMotor, '{Spec:1-Ax:X}Mtr', labels=('samplestage',))
+    tz = Cpt(EpicsMotor, '{Spec:1-Ax:Z}Mtr', labels=('samplestage',))
+    sy = Cpt(EpicsMotor, '{Env:1-Ax:Y}Mtr', labels=('samplestage',))
+    sx = Cpt(EpicsMotor, '{Env:1-Ax:X}Mtr', labels=('samplestage',))
+    sz = Cpt(EpicsMotor, '{Env:1-Ax:Z}Mtr', labels=('samplestage',))
 
 
 analyzer = Analyzer('XF:10IDD', name='analyzer')
@@ -66,8 +68,8 @@ analyzer_slits = AnalyzerSlits('XF:10IDD-ES{Ez4:', name='analyzer_slits')
 mcm_slits = MCMSlits('XF:10IDD-OP{Ez4:', name='mcm_slits')
 sample_stage = SampleStage('XF:10IDD-OP', name='s')
 
-whl = EpicsMotor('XF:10IDD-OP{Abs:1-Ax:Wheel}Mtr', name='whl')
+whl = EpicsMotor('XF:10IDD-OP{Abs:1-Ax:Wheel}Mtr', name='whl', labels=('whl',))
 
-anapd = EpicsMotor('XF:10IDD-ES{Ez4:8-Ax:3}Mtr', name='anapd')
-anpd = EpicsMotor('XF:10IDD-ES{Ez4:5-Ax:1}Mtr', name='anpd')
+anapd = EpicsMotor('XF:10IDD-ES{Ez4:8-Ax:3}Mtr', name='anapd', labels=('anapd',))
+anpd = EpicsMotor('XF:10IDD-ES{Ez4:5-Ax:1}Mtr', name='anpd', labels=('anpd',))
 # name_you_want = EpicsMotor(PVNAME_BASE, name='name_you_want')

--- a/startup/99-plans.py
+++ b/startup/99-plans.py
@@ -100,15 +100,15 @@ def Lipid_Qscan():
             yield from set_lambda_exposure(5)
             loc_peaks = yield from align_with_fit([lambda_det], sample_stage.sy, -0.1, 0.1, 40)
             max_pos = local_peaks[0].max
-            yield from bps.mvr(ample_stage.sy, -0.1)
-            yield from bps.mv(ample_stage.sy, max_pos)
+            yield from bps.mvr(sample_stage.sy, -0.1)
+            yield from bps.mv(sample_stage.sy, max_pos)
             loc_peaks = yield from align_with_fit([lambda_det], sample_stage.sz, -2, 2, 40)
             max_pos = local_peaks[0].max
             yield from bps.mv(sample_stage.sz, max_pos)
             loc_peaks = yield from align_with_fit([lambda_det], sample_stage.sy, -0.1, 0.1, 40)
             max_pos = local_peaks[0].max
-            yield from bps.mvr(ample_stage.sy, -0.1)
-            yield from bps.mv(ample_stage.sy, max_pos)
+            yield from bps.mvr(sample_stage.sy, -0.1)
+            yield from bps.mv(sample_stage.sy, max_pos)
 
         yield from bps.mv(anapd, 3, spec.tth, 1)
         yield from bps.mv(sclr.channels.chan22.preset_time, 5)
@@ -258,6 +258,24 @@ def mcm_setup(s1=0, s2=0):
         return
     if not s1 == 0:
         yield from bp.rel_scan([det2], mcm.x, -0.2, 0.2, 41)
+        x_pos = calculate_max_value(uid=-1, x="mcm.x", y="det2_current1_mean_value", delta=1, sampling=100)
+        xmax = x_pos[0]
+        dxmax = MCM_XPOS - xmax
+        print(f"Maximum position X = {xmax}. Shifted by {dxmax} from the target")
+        kc = 1
+        while abs(dxmax) > 1.0e-3:
+            yield from bps.mvr(sample_stage.tx, dxmax)
+            yield from bp.rel_scan([det2], mcm.x, -0.2, 0.2, 41)
+            x_pos = calculate_max_value(uid=-1, x="mcm.x", y="det2_current1_mean_value", delta=1, sampling=100)
+            xmax = x_pos[0]
+            dxmax = MCM_XPOS - xmax
+            print(f"Maximum position X = {xmax}. Shifted by {dxmax} from the target")
+            kc += 1
+            if kc > 5:
+                print("Could not set the MCM_X to maximum. Execution aborted")
+                break
+
+
 
 
 def calculate_max_value(uid=-1, x="hrmE", y="lambda_det_stats7_total", delta=1, sampling=200):


### PR DESCRIPTION
This PR add labels to all EpicsMotors objects.
The goal behind it is to use `%wa device_label` to retrieve information on the objects of interest only